### PR TITLE
introduce more return type providers

### DIFF
--- a/src/Argument.php
+++ b/src/Argument.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Psalm;
+
+use PhpParser;
+use Psalm\StatementsSource;
+use Psalm\Type;
+
+final class Argument
+{
+    /**
+     * @param list<PhpParser\Node\Arg> $arguments
+     * @param 0|positive-int $index
+     */
+    public static function getType(
+        array $arguments,
+        StatementsSource $statements_source,
+        int $index
+    ): ?Type\Union {
+        $argument = $arguments[$index] ?? null;
+        if (null === $argument) {
+            return null;
+        }
+
+        return $statements_source->getNodeTypeProvider()->getType($argument->value);
+    }
+}

--- a/src/EventHandler/Iter/Count/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Iter/Count/FunctionReturnTypeProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Psalm\EventHandler\Iter\Count;
+
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psl\Psalm\Argument;
+
+use function count;
+
+final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @return non-empty-list<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return [
+            'psl\str\count',
+        ];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
+        if (null === $argument_type) {
+            return Type::getInt();
+        }
+
+        $array_argument_type = $argument_type->getAtomicTypes()['array'] ?? null;
+        if (null === $array_argument_type) {
+            return Type::getInt();
+        }
+
+        // non-empty-array/non-empty-list -> positive-int / literal-int
+        if ($array_argument_type instanceof Type\Atomic\TNonEmptyList) {
+            $count = $array_argument_type->count;
+            if (null === $count) {
+                return Type::getPositiveInt();
+            }
+
+            return Type::getInt(false, $count);
+        }
+
+        if ($array_argument_type instanceof Type\Atomic\TNonEmptyArray) {
+            $count = $array_argument_type->count;
+            if (null === $count) {
+                return Type::getPositiveInt();
+            }
+
+            return Type::getInt(false, $count);
+        }
+
+        // array{foo: bar} -> literal-int(1)
+        if ($array_argument_type instanceof Type\Atomic\TKeyedArray) {
+            return Type::getInt(false, count($array_argument_type->properties));
+        }
+
+        return Type::getInt();
+    }
+}

--- a/src/EventHandler/Iter/First/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Iter/First/FunctionReturnTypeProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Psalm\EventHandler\Iter\First;
+
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psl\Psalm\Argument;
+
+final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @return non-empty-list<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return [
+            'psl\iter\first',
+        ];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
+        if (null === $argument_type) {
+            return null;
+        }
+
+        $array_argument_type = $argument_type->getAtomicTypes()['array'] ?? null;
+        if (null === $array_argument_type) {
+            return null;
+        }
+
+        if ($array_argument_type instanceof Type\Atomic\TNonEmptyArray) {
+            return clone $array_argument_type->type_params[1];
+        }
+
+        if ($array_argument_type instanceof Type\Atomic\TNonEmptyList) {
+            return clone $array_argument_type->type_param;
+        }
+
+        if ($array_argument_type instanceof Type\Atomic\TKeyedArray) {
+            // TODO(azjezz): add support for this once psalm starts enforcing the shape order ( if ever ).
+            //
+            // foreach ($properties as $property) {
+            //     return clone $property;
+            // }
+            return clone $array_argument_type->getGenericValueType();
+        }
+
+        return null;
+    }
+}

--- a/src/EventHandler/Iter/Last/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Iter/Last/FunctionReturnTypeProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Psalm\EventHandler\Iter\Last;
+
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psl\Psalm\Argument;
+
+final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @return non-empty-list<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return [
+            'psl\iter\last',
+        ];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
+        if (null === $argument_type) {
+            return null;
+        }
+
+        $array_argument_type = $argument_type->getAtomicTypes()['array'] ?? null;
+        if (null === $array_argument_type) {
+            return null;
+        }
+
+        if ($array_argument_type instanceof Type\Atomic\TNonEmptyArray) {
+            return clone $array_argument_type->type_params[1];
+        }
+
+        if ($array_argument_type instanceof Type\Atomic\TNonEmptyList) {
+            return clone $array_argument_type->type_param;
+        }
+
+        if ($array_argument_type instanceof Type\Atomic\TKeyedArray) {
+            // TODO(azjezz): add support for this once psalm starts enforcing the shape order ( if ever ).
+            //
+            // $properties = $array_argument_type->properties;
+            // $last_property = null;
+            // foreach ($properties as $property) {
+            //     $last_property = $property;
+            // }
+            //
+            // return clone $last_property;
+            return clone $array_argument_type->getGenericValueType();
+        }
+
+        return null;
+    }
+}

--- a/src/EventHandler/Str/After/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Str/After/FunctionReturnTypeProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Psalm\EventHandler\Str\After;
+
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psl\Psalm\Argument;
+
+final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @return non-empty-list<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return [
+            'psl\str\after',
+            'psl\str\after_ci',
+            'psl\str\after_last',
+            'psl\str\after_last_ci',
+            'psl\str\byte\after',
+            'psl\str\byte\after_ci',
+            'psl\str\byte\after_last',
+            'psl\str\byte\after_last_ci',
+            'psl\str\grapheme\after',
+            'psl\str\grapheme\after_ci',
+            'psl\str\grapheme\after_last',
+            'psl\str\grapheme\after_last_ci',
+        ];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
+        if ($argument_type === null || !$argument_type->hasLowercaseString()) {
+            return Type::combineUnionTypes(Type::getNull(), Type::getString());
+        }
+
+        return new Type\Union([new Type\Atomic\TLowercaseString(), new Type\Atomic\TNull()]);
+    }
+}

--- a/src/EventHandler/Str/Before/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Str/Before/FunctionReturnTypeProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Psalm\EventHandler\Str\Before;
+
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psl\Psalm\Argument;
+
+final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @return non-empty-list<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return [
+            'psl\str\before',
+            'psl\str\before_ci',
+            'psl\str\before_last',
+            'psl\str\before_last_ci',
+            'psl\str\byte\before',
+            'psl\str\byte\before_ci',
+            'psl\str\byte\before_last',
+            'psl\str\byte\before_last_ci',
+            'psl\str\grapheme\before',
+            'psl\str\grapheme\before_ci',
+            'psl\str\grapheme\before_last',
+            'psl\str\grapheme\before_last_ci',
+        ];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
+        if ($argument_type === null || !$argument_type->hasLowercaseString()) {
+            return Type::combineUnionTypes(Type::getNull(), Type::getString());
+        }
+
+        return new Type\Union([new Type\Atomic\TNull(), new Type\Atomic\TLowercaseString()]);
+    }
+}

--- a/src/EventHandler/Str/Chunk/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Str/Chunk/FunctionReturnTypeProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Psalm\EventHandler\Str\Chunk;
+
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psl\Psalm\Argument;
+
+final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @return non-empty-list<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return [
+            'psl\str\chunk',
+            'psl\str\byte\chunk',
+        ];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
+        if (null === $argument_type) {
+            // [unknown] -> list<string>
+            return new Type\Union([new Type\Atomic\TList(new Type\Union([new Type\Atomic\TString()]))]);
+        }
+
+        $string_argument_type = $argument_type->getAtomicTypes()['string'] ?? null;
+        if (null === $string_argument_type) {
+            // [unknown] -> list<string>
+            return new Type\Union([new Type\Atomic\TList(new Type\Union([new Type\Atomic\TString()]))]);
+        }
+
+        if ($string_argument_type instanceof Type\Atomic\TNonEmptyString) {
+            // non-empty-lowercase-string => non-empty-list<non-empty-lowercase-string>
+            if ($string_argument_type instanceof Type\Atomic\TNonEmptyLowercaseString) {
+                return new Type\Union([
+                    new Type\Atomic\TNonEmptyList(new Type\Union([
+                        new Type\Atomic\TNonEmptyLowercaseString()
+                    ]))
+                ]);
+            }
+
+            // non-empty-string => non-empty-list<non-empty-string>
+            return new Type\Union([new Type\Atomic\TNonEmptyList(new Type\Union([new Type\Atomic\TNonEmptyString()]))]);
+        }
+
+        // string -> list<string>
+        return new Type\Union([new Type\Atomic\TList(new Type\Union([new Type\Atomic\TString()]))]);
+    }
+}

--- a/src/EventHandler/Str/Lowercase/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Str/Lowercase/FunctionReturnTypeProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Psl\Psalm\EventHandler\Type\Optional;
+namespace Psl\Psalm\EventHandler\Str\Lowercase;
 
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
@@ -17,20 +17,23 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
     public static function getFunctionIds(): array
     {
         return [
-            'psl\type\optional'
+            'psl\str\lowercase',
+            'psl\str\byte\lowercase',
         ];
     }
 
     public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
     {
         $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
-        if (null === $argument_type) {
-            return null;
+        if ($argument_type === null) {
+            return new Type\Union([new Type\Atomic\TLowercaseString()]);
         }
 
-        $clone = clone $argument_type;
-        $clone->possibly_undefined = true;
+        $string_argument_type = $argument_type->getAtomicTypes()['string'] ?? null;
+        if ($string_argument_type instanceof Type\Atomic\TNonEmptyString) {
+            return new Type\Union([new Type\Atomic\TNonEmptyLowercaseString()]);
+        }
 
-        return $clone;
+        return new Type\Union([new Type\Atomic\TLowercaseString()]);
     }
 }

--- a/src/EventHandler/Str/Repeat/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Str/Repeat/FunctionReturnTypeProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Psalm\EventHandler\Str\Repeat;
+
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psl\Psalm\Argument;
+
+use function str_repeat;
+
+final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @return non-empty-list<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return [
+            'psl\str\repeat',
+        ];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
+        if ($argument_type === null || !$argument_type->hasLowercaseString()) {
+            return Type::getString();
+        }
+
+        $string_argument_type = $argument_type->getAtomicTypes()['string'] ?? null;
+        if ($string_argument_type instanceof Type\Atomic\TNonEmptyString) {
+            if ($string_argument_type instanceof Type\Atomic\TNonEmptyLowercaseString) {
+                return new Type\Union([new Type\Atomic\TNonEmptyLowercaseString()]);
+            }
+
+            return new Type\Union([new Type\Atomic\TNonEmptyString()]);
+        }
+
+        if ($string_argument_type instanceof Type\Atomic\TLowercaseString) {
+            return new Type\Union([new Type\Atomic\TLowercaseString()]);
+        }
+
+        if ($string_argument_type instanceof Type\Atomic\TLiteralString) {
+            $multiplier_argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 1);
+            if (null !== $multiplier_argument_type && $multiplier_argument_type->hasLiteralInt()) {
+                /** @psalm-suppress MissingThrowsDocblock */
+                return Type::getString(str_repeat(
+                    $string_argument_type->value,
+                    $multiplier_argument_type->getSingleIntLiteral()->value
+                ));
+            }
+        }
+
+        return Type::getString();
+    }
+}

--- a/src/EventHandler/Str/Slice/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Str/Slice/FunctionReturnTypeProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Psl\Psalm\EventHandler\Type\Optional;
+namespace Psl\Psalm\EventHandler\Str\Slice;
 
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
@@ -17,20 +17,19 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
     public static function getFunctionIds(): array
     {
         return [
-            'psl\type\optional'
+            'psl\str\slice',
+            'psl\str\byte\slice',
+            'psl\str\grapheme\slice'
         ];
     }
 
     public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
     {
         $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
-        if (null === $argument_type) {
-            return null;
+        if ($argument_type === null || !$argument_type->hasLowercaseString()) {
+            return Type::getString();
         }
 
-        $clone = clone $argument_type;
-        $clone->possibly_undefined = true;
-
-        return $clone;
+        return new Type\Union([new Type\Atomic\TLowercaseString()]);
     }
 }

--- a/src/EventHandler/Str/Splice/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Str/Splice/FunctionReturnTypeProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Psl\Psalm\EventHandler\Type\Optional;
+namespace Psl\Psalm\EventHandler\Str\Splice;
 
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
@@ -17,20 +17,24 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
     public static function getFunctionIds(): array
     {
         return [
-            'psl\type\optional'
+            'psl\str\splice',
+            'psl\str\byte\splice',
         ];
     }
 
     public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
     {
         $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
-        if (null === $argument_type) {
-            return null;
+        $replacement_argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 1);
+
+        if ($argument_type === null || $replacement_argument_type === null) {
+            return Type::getString();
         }
 
-        $clone = clone $argument_type;
-        $clone->possibly_undefined = true;
+        if (!$argument_type->hasLowercaseString() || !$replacement_argument_type->hasLowercaseString()) {
+            return Type::getString();
+        }
 
-        return $clone;
+        return new Type\Union([new Type\Atomic\TLowercaseString()]);
     }
 }

--- a/src/EventHandler/Str/Split/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Str/Split/FunctionReturnTypeProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Psalm\EventHandler\Str\Split;
+
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psl\Psalm\Argument;
+
+final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @return non-empty-list<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return [
+            'psl\str\split',
+            'psl\str\byte\split',
+        ];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
+        if (null === $argument_type) {
+            // [unknown] -> list<string>
+            return new Type\Union([new Type\Atomic\TList(new Type\Union([new Type\Atomic\TString()]))]);
+        }
+
+        $string_argument_type = $argument_type->getAtomicTypes()['string'] ?? null;
+        if (null === $string_argument_type) {
+            // [unknown] -> list<string>
+            return new Type\Union([new Type\Atomic\TList(new Type\Union([new Type\Atomic\TString()]))]);
+        }
+
+        if ($string_argument_type instanceof Type\Atomic\TNonEmptyString) {
+            // non-empty-lowercase-string => non-empty-list<non-empty-lowercase-string>
+            if ($string_argument_type instanceof Type\Atomic\TNonEmptyLowercaseString) {
+                return new Type\Union([
+                    new Type\Atomic\TNonEmptyList(new Type\Union([
+                        new Type\Atomic\TNonEmptyLowercaseString()
+                    ]))
+                ]);
+            }
+
+            // non-empty-string => non-empty-list<non-empty-string>
+            return new Type\Union([new Type\Atomic\TNonEmptyList(new Type\Union([new Type\Atomic\TNonEmptyString()]))]);
+        }
+
+        // string -> list<string>
+        return new Type\Union([new Type\Atomic\TList(new Type\Union([new Type\Atomic\TString()]))]);
+    }
+}

--- a/src/EventHandler/Str/Uppercase/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Str/Uppercase/FunctionReturnTypeProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Psl\Psalm\EventHandler\Type\Optional;
+namespace Psl\Psalm\EventHandler\Str\Uppercase;
 
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
@@ -17,7 +17,8 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
     public static function getFunctionIds(): array
     {
         return [
-            'psl\type\optional'
+            'psl\str\uppercase',
+            'psl\str\byte\uppercase',
         ];
     }
 
@@ -25,12 +26,18 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
     {
         $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
         if (null === $argument_type) {
-            return null;
+            return Type::getString();
         }
 
-        $clone = clone $argument_type;
-        $clone->possibly_undefined = true;
+        $string_argument_type = $argument_type->getAtomicTypes()['string'] ?? null;
+        if (null === $string_argument_type) {
+            return Type::getString();
+        }
 
-        return $clone;
+        if ($string_argument_type instanceof Type\Atomic\TNonEmptyString) {
+            return new Type\Union([new Type\Atomic\TNonEmptyString()]);
+        }
+
+        return Type::getString();
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,18 +4,51 @@ declare(strict_types=1);
 
 namespace Psl\Psalm;
 
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Plugin\PluginEntryPointInterface;
 use Psalm\Plugin\RegistrationInterface;
 use SimpleXMLElement;
+
+use function str_replace;
 
 final class Plugin implements PluginEntryPointInterface
 {
     public function __invoke(RegistrationInterface $registration, ?SimpleXMLElement $config = null): void
     {
-        require_once __DIR__ . '/EventHandler/Type/Optional/FunctionReturnTypeProvider.php';
-        require_once __DIR__ . '/EventHandler/Type/Shape/FunctionReturnTypeProvider.php';
+        require_once __DIR__ . '/Argument.php';
+        foreach ($this->getHooks() as $hook) {
+            /** @psalm-suppress UnresolvableInclude */
+            require_once __DIR__ . '/' . str_replace([__NAMESPACE__, '\\'], ['', '/'], $hook) . '.php';
 
-        $registration->registerHooksFromClass(EventHandler\Type\Optional\FunctionReturnTypeProvider::class);
-        $registration->registerHooksFromClass(EventHandler\Type\Shape\FunctionReturnTypeProvider::class);
+            $registration->registerHooksFromClass($hook);
+        }
+    }
+
+    /**
+     * @return iterable<class-string<FunctionReturnTypeProviderInterface>>
+     */
+    private function getHooks(): iterable
+    {
+        // Psl\Iter hooks
+        yield EventHandler\Iter\First\FunctionReturnTypeProvider::class;
+        yield EventHandler\Iter\Last\FunctionReturnTypeProvider::class;
+        yield EventHandler\Iter\Count\FunctionReturnTypeProvider::class;
+
+        // Psl\Str hooks
+        yield EventHandler\Str\After\FunctionReturnTypeProvider::class;
+        yield EventHandler\Str\Before\FunctionReturnTypeProvider::class;
+        yield EventHandler\Str\Chunk\FunctionReturnTypeProvider::class;
+        yield EventHandler\Str\Lowercase\FunctionReturnTypeProvider::class;
+        yield EventHandler\Str\Repeat\FunctionReturnTypeProvider::class;
+        yield EventHandler\Str\Repeat\FunctionReturnTypeProvider::class;
+        yield EventHandler\Str\Repeat\FunctionReturnTypeProvider::class;
+        yield EventHandler\Str\Slice\FunctionReturnTypeProvider::class;
+        yield EventHandler\Str\Splice\FunctionReturnTypeProvider::class;
+        yield EventHandler\Str\Split\FunctionReturnTypeProvider::class;
+        yield EventHandler\Str\Uppercase\FunctionReturnTypeProvider::class;
+
+        // Psl\Iter hooks
+        yield EventHandler\Type\Optional\FunctionReturnTypeProvider::class;
+        yield EventHandler\Type\Shape\FunctionReturnTypeProvider::class;
     }
 }


### PR DESCRIPTION
new return type providers:

- `Iter\count` return `positive-int` when `$iterable` is a `non-empty-list<_>`.
- `Iter\count` return `positive-int` when `$iterable` is a `non-empty-array<_, _>`.
- `Iter\count` return `int(0)` when `$iterable` is `empty&array<_, _>`
- `Iter\count` return `int(x)` when `$iterable` is a `non-empty-list<_>` with a known count, where `x` is the size of `$iterable`.
- `Iter\count` return `int(x)` when `$iterable` is a `non-empty-array<_, _>` with a known count, where `x` is the size of `$iterable`.
- `Iter\last` return `Tv` when `$iterable` is a `non-empty-list<Tv>`.
- `Iter\last` return `Tv` when `$iterable` is a `non-empty-array<_, Tv>`.
- `Iter\last` return `null` when `$iterable` is `empty&array<_, _>`
- `Iter\last` return `Tv` when `$iterable` is  `array{...}` with at least 1 property.
- `Iter\first` return `Tv` when `$iterable` is a `non-empty-list<Tv>`.
- `Iter\first` return `Tv` when `$iterable` is a `non-empty-array<_, Tv>`.
- `Iter\first` return `null` when `$iterable` is `empty&array<_, _>`
- `Iter\first` return `Tv` when `$iterable` is  `array{...}` with at least 1 property.
- `Str\after` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\after_last` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\after_ci` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\after_last_ci` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\before` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\before_last` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\before_ci` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\before_last_ci` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Byte\after` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Byte\after_last` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Byte\after_ci` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Byte\after_last_ci` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Byte\before` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Byte\before_last` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Byte\before_ci` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Byte\before_last_ci` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Grapheme\after` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Grapheme\after_last` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Grapheme\after_ci` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Grapheme\after_last_ci` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Grapheme\before` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Grapheme\before_last` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Grapheme\before_ci` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\Grapheme\before_last_ci` return `null|lowercase-string` when the first argument is `lowercase-string`.
- `Str\chunk` returns `non-empty-list<non-empty-string>` if `$string` is `non-empty-string`
- `Str\chunk` returns `non-empty-list<non-empty-lowercase-string>` if `$string` is `non-empty-lowercase-string`
- `Str\Byte\chunk` returns `non-empty-list<non-empty-string>` if `$string` is `non-empty-string`
- `Str\Byte\chunk` returns `non-empty-list<non-empty-lowercase-string>` if `$string` is `non-empty-lowercase-string`
- `Str\lowercase` returns `non-empty-lowercase-string` if `$string` is `non-empty-string` or `non-falsy-string`
- `Str\Byte\lowercase` returns `non-empty-lowercase-string` if `$string` is `non-empty-string` or `non-falsy-string`
- `Str\repeat` returns `non-empty-lowercase-string` if `$string` is `non-empty-lowercase-string`
- `Str\repeat` returns `non-empty-string` if `$string` is `non-empty-string`
- `Str\repeat` returns `lowercase-string` if `$string` is `lowercase-string`
- `Str\repeat` returns `string(x)` if `$string` is a literal, and `$multiplier` is literal, where `x` is the result.
- `Str\slice` returns `lowercase-string` if `$string` is `lowercase-string`
- `Str\Byte\slice` returns `lowercase-string` if `$string` is `lowercase-string`
- `Str\Grapheme\slice` returns `lowercase-string` if `$string` is `lowercase-string`
- `Str\splice` returns `lowercase-string` if `$string` is `lowercase-string` and `$replacement` is `lowercase-string`
- `Str\Byte\splice` returns `lowercase-string` if `$string` is `lowercase-string` and `$replacement` is `lowercase-string`
- `Str\split` returns `non-empty-list<non-empty-string>` if `$string` is `non-empty-string`
- `Str\split` returns `non-empty-list<non-empty-lowercase-string>` if `$string` is `non-empty-lowercase-string`
- `Str\Byte\split` returns `non-empty-list<non-empty-string>` if `$string` is `non-empty-string`
- `Str\Byte\split` returns `non-empty-list<non-empty-lowercase-string>` if `$string` is `non-empty-lowercase-string`
- `Str\uppercase` returns `non-empty-string` if `$string` is `non-empty-string`
- `Str\Byte\uppercase` returns `non-empty-string` if `$string` is `non-empty-string`