### PR TITLE
Psalm5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ and correct type of `array{name: string, age: int, location?: array{city: string
 
 ## Compatibility
 
-| PSL | Psalm plugin |
-|-----|--------------|
-| 2.x | 2.x          |
-| 1.x | 1.x          |
+| PSL | Psalm plugin | Psalm |
+|-----|------------|-------|
+| 2.x | ^2.1       | v5    |
+| 2.x | ~2.0.0     | v4    |
+| 1.x | 1.x        | v4    |
 
 ## Sponsors
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "vimeo/psalm": "^4.20 || ^5.0"
+        "vimeo/psalm": "^5.0"
     },
     "conflict": {
         "azjezz/psl": "<2.0"

--- a/src/EventHandler/Iter/First/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Iter/First/FunctionReturnTypeProvider.php
@@ -34,20 +34,20 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
         }
 
         if ($array_argument_type instanceof Type\Atomic\TNonEmptyArray) {
-            return clone $array_argument_type->type_params[1];
+            return $array_argument_type->type_params[1];
         }
 
         if ($array_argument_type instanceof Type\Atomic\TNonEmptyList) {
-            return clone $array_argument_type->type_param;
+            return $array_argument_type->type_param;
         }
 
         if ($array_argument_type instanceof Type\Atomic\TKeyedArray) {
             // TODO(azjezz): add support for this once psalm starts enforcing the shape order ( if ever ).
             //
             // foreach ($properties as $property) {
-            //     return clone $property;
+            //     return $property;
             // }
-            return clone $array_argument_type->getGenericValueType();
+            return $array_argument_type->getGenericValueType();
         }
 
         return null;

--- a/src/EventHandler/Iter/FirstKey/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Iter/FirstKey/FunctionReturnTypeProvider.php
@@ -34,7 +34,7 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
         }
 
         if ($array_argument_type instanceof Type\Atomic\TNonEmptyArray) {
-            return clone $array_argument_type->type_params[0];
+            return $array_argument_type->type_params[0];
         }
 
         if ($array_argument_type instanceof Type\Atomic\TNonEmptyList) {
@@ -45,9 +45,9 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
             // TODO(azjezz): add support for this once psalm starts enforcing the shape order ( if ever ).
             //
             // foreach ($properties as $property) {
-            //     return clone $property;
+            //     return $property;
             // }
-            return clone $array_argument_type->getGenericKeyType();
+            return $array_argument_type->getGenericKeyType();
         }
 
         return null;

--- a/src/EventHandler/Iter/Last/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Iter/Last/FunctionReturnTypeProvider.php
@@ -34,11 +34,11 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
         }
 
         if ($array_argument_type instanceof Type\Atomic\TNonEmptyArray) {
-            return clone $array_argument_type->type_params[1];
+            return $array_argument_type->type_params[1];
         }
 
         if ($array_argument_type instanceof Type\Atomic\TNonEmptyList) {
-            return clone $array_argument_type->type_param;
+            return $array_argument_type->type_param;
         }
 
         if ($array_argument_type instanceof Type\Atomic\TKeyedArray) {
@@ -50,8 +50,8 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
             //     $last_property = $property;
             // }
             //
-            // return clone $last_property;
-            return clone $array_argument_type->getGenericValueType();
+            // return $last_property;
+            return $array_argument_type->getGenericValueType();
         }
 
         return null;

--- a/src/EventHandler/Iter/LastKey/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Iter/LastKey/FunctionReturnTypeProvider.php
@@ -34,7 +34,7 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
         }
 
         if ($array_argument_type instanceof Type\Atomic\TNonEmptyArray) {
-            return clone $array_argument_type->type_params[0];
+            return $array_argument_type->type_params[0];
         }
 
         if ($array_argument_type instanceof Type\Atomic\TNonEmptyList) {
@@ -50,8 +50,8 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
             //     $last_property = $property;
             // }
             //
-            // return clone $last_property;
-            return clone $array_argument_type->getGenericKeyType();
+            // return $last_property;
+            return $array_argument_type->getGenericKeyType();
         }
 
         return null;

--- a/src/EventHandler/Type/Optional/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Type/Optional/FunctionReturnTypeProvider.php
@@ -28,9 +28,6 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
             return null;
         }
 
-        $clone = clone $argument_type;
-        $clone->possibly_undefined = true;
-
-        return $clone;
+        return $argument_type->setPossiblyUndefined(true);
     }
 }

--- a/src/EventHandler/Type/Shape/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Type/Shape/FunctionReturnTypeProvider.php
@@ -57,8 +57,8 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
                 return null;
             }
 
-            $property_type = clone $type->type_params[0];
-            $property_type->possibly_undefined = $value->possibly_undefined;
+            $property_type = $type->type_params[0];
+            $property_type = $property_type->setPossiblyUndefined($value->possibly_undefined);
 
             $properties[$name] = $property_type;
         }


### PR DESCRIPTION
Psalm v5 is out!

This PR contains:

* fixes for psalm v5 (it now has immutable non-cloneable union types)


PSL itself cannot use psalm5 unless `roave/infection-static-analysis-plugin` supports psalm v5.

- [x] https://github.com/Roave/infection-static-analysis-plugin/pull/461

There are 30-ish new psalm warnings in psalm v5 atm which need to be addressed in the psl package.