### PR TITLE
Fixed PHP 8.2 deprecations

### DIFF
--- a/src/EventHandler/Fun/Pipe/PipeArgumentsProvider.php
+++ b/src/EventHandler/Fun/Pipe/PipeArgumentsProvider.php
@@ -46,7 +46,7 @@ final class PipeArgumentsProvider implements DynamicFunctionStorageProviderInter
         $pipe_storage->params = [
             ...array_map(
                 static fn(TClosure $callable, int $offset) => self::createParam(
-                    "fn_${offset}",
+                    "fn_{$offset}",
                     new Union([$callable]),
                 ),
                 $pipe_callables,
@@ -75,7 +75,7 @@ final class PipeArgumentsProvider implements DynamicFunctionStorageProviderInter
         DynamicTemplateProvider $template_provider,
         int $offset
     ): TTemplateParam {
-        return $template_provider->createTemplate("T${offset}");
+        return $template_provider->createTemplate("T{$offset}");
     }
 
     private static function createABClosure(


### PR DESCRIPTION
Using ${var} string interpolation is deprecated in PHP 8.2