### PR TITLE
feat: add `Psl\Type\nullish()` return type provider

### DIFF
--- a/src/EventHandler/Iter/Count/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Iter/Count/FunctionReturnTypeProvider.php
@@ -35,16 +35,7 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
             return Type::getInt();
         }
 
-        // non-empty-array/non-empty-list -> positive-int / literal-int
-        if ($array_argument_type instanceof Type\Atomic\TNonEmptyList) {
-            $count = $array_argument_type->count;
-            if (null === $count) {
-                return new Type\Union([new Type\Atomic\TIntRange(1, null)]);
-            }
-
-            return Type::getInt(false, $count);
-        }
-
+        // non-empty-array -> positive-int / literal-int
         if ($array_argument_type instanceof Type\Atomic\TNonEmptyArray) {
             $count = $array_argument_type->count;
             if (null === $count) {

--- a/src/EventHandler/Iter/First/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Iter/First/FunctionReturnTypeProvider.php
@@ -37,10 +37,6 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
             return $array_argument_type->type_params[1];
         }
 
-        if ($array_argument_type instanceof Type\Atomic\TNonEmptyList) {
-            return $array_argument_type->type_param;
-        }
-
         if ($array_argument_type instanceof Type\Atomic\TKeyedArray) {
             // TODO(azjezz): add support for this once psalm starts enforcing the shape order ( if ever ).
             //

--- a/src/EventHandler/Iter/FirstKey/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Iter/FirstKey/FunctionReturnTypeProvider.php
@@ -37,10 +37,6 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
             return $array_argument_type->type_params[0];
         }
 
-        if ($array_argument_type instanceof Type\Atomic\TNonEmptyList) {
-            return Type::getInt();
-        }
-
         if ($array_argument_type instanceof Type\Atomic\TKeyedArray) {
             // TODO(azjezz): add support for this once psalm starts enforcing the shape order ( if ever ).
             //

--- a/src/EventHandler/Iter/Last/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Iter/Last/FunctionReturnTypeProvider.php
@@ -37,10 +37,6 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
             return $array_argument_type->type_params[1];
         }
 
-        if ($array_argument_type instanceof Type\Atomic\TNonEmptyList) {
-            return $array_argument_type->type_param;
-        }
-
         if ($array_argument_type instanceof Type\Atomic\TKeyedArray) {
             // TODO(azjezz): add support for this once psalm starts enforcing the shape order ( if ever ).
             //

--- a/src/EventHandler/Iter/LastKey/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Iter/LastKey/FunctionReturnTypeProvider.php
@@ -37,10 +37,6 @@ final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInte
             return $array_argument_type->type_params[0];
         }
 
-        if ($array_argument_type instanceof Type\Atomic\TNonEmptyList) {
-            return Type::getInt();
-        }
-
         if ($array_argument_type instanceof Type\Atomic\TKeyedArray) {
             // TODO(azjezz): add support for this once psalm starts enforcing the shape order ( if ever ).
             //

--- a/src/EventHandler/Type/Nullish/FunctionReturnTypeProvider.php
+++ b/src/EventHandler/Type/Nullish/FunctionReturnTypeProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psl\Psalm\EventHandler\Type\Nullish;
+
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psl\Psalm\Argument;
+
+final class FunctionReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @return non-empty-list<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return [
+            'psl\type\nullish'
+        ];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $argument_type = Argument::getType($event->getCallArgs(), $event->getStatementsSource(), 0);
+        if (null === $argument_type) {
+            return null;
+        }
+
+        return Type::combineUnionTypes($argument_type, Type::getNull());
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -58,7 +58,8 @@ final class Plugin implements PluginEntryPointInterface
         yield EventHandler\Str\Split\FunctionReturnTypeProvider::class;
         yield EventHandler\Str\Uppercase\FunctionReturnTypeProvider::class;
 
-        // Psl\Iter hooks
+        // Psl\Type hooks
+        yield EventHandler\Type\Nullish\FunctionReturnTypeProvider::class;
         yield EventHandler\Type\Optional\FunctionReturnTypeProvider::class;
         yield EventHandler\Type\Shape\FunctionReturnTypeProvider::class;
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,6 +12,7 @@ use SimpleXMLElement;
 
 use function str_replace;
 
+/** @psalm-suppress UnusedClass - loaded externally by Psalm */
 final class Plugin implements PluginEntryPointInterface
 {
     public function __invoke(RegistrationInterface $registration, ?SimpleXMLElement $config = null): void


### PR DESCRIPTION
## Summary

- Add return type provider for `Psl\Type\nullish()` that infers `T|null` by combining the argument type with `null` via `Type::combineUnionTypes()`
- Remove dead `TNonEmptyList` branches from Iter handlers (type was removed from Psalm, now represented as `TKeyedArray`/`TNonEmptyArray` which are already handled)
- Suppress `UnusedClass` on `Plugin` (loaded externally by Psalm)

## Test plan

- [x] Psalm passes with zero errors
- [x] New provider mirrors existing `optional()` pattern